### PR TITLE
feat: add language selector and profile data modal to desktop header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "6.6.1-nelp.1",
+  "version": "6.6.1-nelp.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edunext/frontend-component-header",
-      "version": "6.6.1-nelp.1",
+      "version": "6.6.1-nelp.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@edunext/frontend-essentials": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "6.6.1-nelp.1",
+  "version": "6.6.1-nelp.2",
   "description": "The standard header for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,11 +1,14 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import TestRenderer from 'react-test-renderer';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Context as ResponsiveContext } from 'react-responsive';
 
 import Header from './index';
+
+jest.mock('@edx/frontend-platform/auth');
 
 const HeaderComponent = ({ width, contextValue }) => (
   <ResponsiveContext.Provider value={width}>
@@ -20,6 +23,12 @@ const HeaderComponent = ({ width, contextValue }) => (
 );
 
 describe('<Header />', () => {
+  afterEach(() => {
+    TestRenderer.act(() => {
+      TestRenderer.create(null); // desmount any previos tree
+    });
+  });
+
   it('renders correctly for anonymous desktop', () => {
     const contextValue = {
       authenticatedUser: null,
@@ -40,6 +49,8 @@ describe('<Header />', () => {
   });
 
   it('renders correctly for authenticated desktop', () => {
+    const get = jest.fn(() => Promise.reject(new Error('not found')));
+    getAuthenticatedHttpClient.mockReturnValue({ get });
     const contextValue = {
       authenticatedUser: {
         userId: 'abc123',

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { ProfileDataModal } from '@edunext/frontend-essentials';
 
 // Local Components
 import DesktopUserMenuToggleSlot
@@ -15,6 +16,7 @@ import { desktopHeaderMainOrSecondaryMenuDataShape } from './DesktopHeaderMainOr
 import DesktopSecondaryMenuSlot from '../plugin-slots/DesktopSecondaryMenuSlot';
 import DesktopUserMenuSlot from '../plugin-slots/DesktopUserMenuSlot';
 import { desktopUserMenuDataShape } from './DesktopHeaderUserMenu';
+import LanguageSelector from '../language-selector';
 
 // i18n
 import messages from '../Header.messages';
@@ -92,11 +94,13 @@ class DesktopHeader extends React.Component {
               aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}
               className="nav secondary-menu-container align-items-center ml-auto"
             >
+              {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
               {loggedIn
                 ? (
                   <>
                     {this.renderSecondaryMenu()}
                     {this.renderUserMenu()}
+                    <ProfileDataModal />
                   </>
                 ) : this.renderLoggedOutItems()}
             </nav>


### PR DESCRIPTION
## Description
This adds the language selector and profiledata modal to the desktop header.

Issue # [1532](https://edunext.atlassian.net/browse/FUTUREX-1532)

## How to test
You can test this implementation with this [pr](https://github.com/nelc/frontend-app-learner-dashboard/pull/4)

