### PR TITLE
feat: set header rtl styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "6.6.1-nelp.2",
+  "version": "6.6.1-nelp.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edunext/frontend-component-header",
-      "version": "6.6.1-nelp.2",
+      "version": "6.6.1-nelp.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@edunext/frontend-essentials": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "6.6.1-nelp.2",
+  "version": "6.6.1-nelp.3",
   "description": "The standard header for Open edX",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/__snapshots__/Header.test.jsx.snap
+++ b/src/__snapshots__/Header.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`<Header /> renders correctly for anonymous desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <a
           className="btn mr-2 btn-link"
@@ -237,7 +237,7 @@ exports[`<Header /> renders correctly for authenticated desktop 1`] = `
       </nav>
       <nav
         aria-label="Secondary"
-        className="nav secondary-menu-container align-items-center ml-auto"
+        className="nav secondary-menu-container align-items-center"
       >
         <div
           className="menu null"

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -92,7 +92,7 @@ class DesktopHeader extends React.Component {
             </nav>
             <nav
               aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}
-              className="nav secondary-menu-container align-items-center ml-auto"
+              className="nav secondary-menu-container align-items-center"
             >
               {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
               {loggedIn

--- a/src/index.scss
+++ b/src/index.scss
@@ -45,9 +45,13 @@ $rounded-pill: 50rem  !default;
     }
   }
 
-  .user-dropdown .btn {
-    height: 3rem;
+  .user-dropdown{
+    margin-left: var(--pgn-spacing-spacer-base);
+    .btn {
+      height: 3rem;
+    }
   }
+
 }
 
 .site-header-mobile,
@@ -93,6 +97,8 @@ $rounded-pill: 50rem  !default;
     }
   }
   .secondary-menu-container {
+    margin-left: auto;
+
     .nav-link:hover,
     .nav-link:focus,
     .nav-link.active,

--- a/src/language-selector/LanguageSelector.scss
+++ b/src/language-selector/LanguageSelector.scss
@@ -1,5 +1,5 @@
 .language-selector {
-  padding: .75rem;
+  padding: 0 var(--pgn-spacing-spacer-base);
 
   .dropdown-toggle {
     .lang-label-medium,

--- a/src/learning-header/AuthenticatedUserDropdown.jsx
+++ b/src/learning-header/AuthenticatedUserDropdown.jsx
@@ -36,7 +36,7 @@ const AuthenticatedUserDropdown = ({ intl, username }) => {
   ];
 
   return (
-    <Dropdown className="user-dropdown ml-3">
+    <Dropdown className="user-dropdown">
       <Dropdown.Toggle variant="outline-primary" aria-label={intl.formatMessage(messages.userOptionsDropdownLabel)}>
         <LearningUserMenuToggleSlot label={username} icon={faUserCircle} />
       </Dropdown.Toggle>


### PR DESCRIPTION
## Description
Set the rtl styles for learning header and site desktop header

## Before (learning header)
<img width="1867" height="714" alt="image" src="https://github.com/user-attachments/assets/0374bb9a-4b6d-4912-91e2-d84929a14ea1" />


## Before (desktop header)
<img width="1898" height="455" alt="image" src="https://github.com/user-attachments/assets/0ebbc002-ea61-4f3f-8951-b45a7d8142ec" />

## After (learning header)
<img width="1911" height="618" alt="image" src="https://github.com/user-attachments/assets/673547dc-542f-4586-8d03-35fef55539d7" />



## After (desktop header)
<img width="1900" height="642" alt="image" src="https://github.com/user-attachments/assets/42fda65d-22c9-4a3b-8a94-7f9a84d252e3" />
