### PR TITLE
feat: add language selector component to header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,34 @@
+name: Trigger Jira Issue Creation
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.pull_request.base.ref }}
+    outputs:
+      story_summary: ${{ vars.MIGRATION_BACKLOG_JIRA_STORY_SUMMARY }}
+      story_description: ${{ vars.MIGRATION_BACKLOG_JIRA_STORY_DESCRIPTION }}
+    steps:
+      - run: echo "Preparing input vars..."
+  create-jira-issue:
+    needs: prepare
+    if: github.event.pull_request.merged == true
+    uses: nelc/actions-hub/.github/workflows/create-jira-issue.yml@main
+    with:
+      story_summary: ${{ needs.prepare.outputs.story_summary }}
+      story_description: ${{ needs.prepare.outputs.story_description }}
+      subtask_summary: "${{ github.event.pull_request.title }}"
+      subtask_description: "${{ github.event.pull_request.body }} 🔗 PR: ${{ github.event.pull_request.html_url }}"
+      environment: ${{ github.event.pull_request.base.ref }}
+    secrets:
+      MIGRATION_BACKLOG_JIRA_EMAIL: ${{ secrets.MIGRATION_BACKLOG_JIRA_EMAIL }}
+      MIGRATION_BACKLOG_JIRA_TOKEN: ${{ secrets.MIGRATION_BACKLOG_JIRA_TOKEN }}
+      MIGRATION_BACKLOG_JIRA_URL: ${{ secrets.MIGRATION_BACKLOG_JIRA_URL }}
+      MIGRATION_BACKLOG_JIRA_PROJECT: ${{ secrets.MIGRATION_BACKLOG_JIRA_PROJECT }}
+      MIGRATION_BACKLOG_JIRA_EPIC_KEY: ${{ secrets.MIGRATION_BACKLOG_JIRA_EPIC_KEY }}
+      MIGRATION_BACKLOG_JIRA_EPIC_LINK_FIELD: ${{ secrets.MIGRATION_BACKLOG_JIRA_EPIC_LINK_FIELD }}

--- a/src/desktop-header/DesktopHeader.jsx
+++ b/src/desktop-header/DesktopHeader.jsx
@@ -15,6 +15,7 @@ import { desktopHeaderMainOrSecondaryMenuDataShape } from './DesktopHeaderMainOr
 import DesktopSecondaryMenuSlot from '../plugin-slots/DesktopSecondaryMenuSlot';
 import DesktopUserMenuSlot from '../plugin-slots/DesktopUserMenuSlot';
 import { desktopUserMenuDataShape } from './DesktopHeaderUserMenu';
+import LanguageSelector from '../language-selector';
 
 // i18n
 import messages from '../Header.messages';
@@ -75,6 +76,7 @@ const DesktopHeader = ({
             aria-label={intl.formatMessage(messages['header.label.secondary.nav'])}
             className="nav secondary-menu-container align-items-center ml-auto"
           >
+            {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
             {loggedIn
               ? (
                 <>

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,6 +7,7 @@ $rounded-pill: 50rem  !default;
 
 @import './Menu/menu.scss';
 @import './studio-header/StudioHeader.scss';
+@import './language-selector/LanguageSelector.scss';
 
 .dropdown-item a {
   text-decoration: none;

--- a/src/language-selector/LanguageSelector.jsx
+++ b/src/language-selector/LanguageSelector.jsx
@@ -1,0 +1,99 @@
+import PropTypes from 'prop-types';
+import React, { useContext, useState } from 'react';
+
+import { changeUserSessionLanguage, getPrimaryLanguageSubtag, injectIntl } from '@edx/frontend-platform/i18n';
+import { getLocale } from '@edx/frontend-platform/i18n/lib';
+import { AppContext } from '@edx/frontend-platform/react';
+import { Dropdown } from '@openedx/paragon';
+import { Language } from '@openedx/paragon/icons';
+
+/**
+ * Gets the localized display name of a language in its own language.
+ *
+ * @function getDisplayName
+ * @param {string} locale - The locale code (e.g., 'en', 'es', 'ar')
+ * @returns {string} The capitalized display name of the language in its native form
+ * @example
+ */
+const getDisplayName = (locale) => {
+  const langName = new Intl.DisplayNames([locale], { type: 'language', languageDisplay: 'standard' }).of(locale);
+  return langName.charAt(0).toUpperCase() + langName.slice(1);
+};
+
+/**
+ * Language Selector component that displays a dropdown allowing users to change the site language.
+ *
+ * The component is responsive and adapts to different screen sizes:
+ * - On large screens: Shows the full language name (e.g., "English")
+ * - On medium screens: Shows the language code (e.g., "EN")
+ * - On small screens: Shows only the language icon
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {string} [props.className=''] - Additional CSS class names to apply to the component
+ * @returns {React.Element|null} The rendered component or null if disabled or no supported languages
+ *
+ * @requires config.SITE_SUPPORTED_LANGUAGES - Must be a non-empty array of locale codes
+ * @requires config.LANGUAGE_PREFERENCE_COOKIE_NAME - Cookie name for storing language preference
+ */
+const LanguageSelector = ({ className }) => {
+  const { config } = useContext(AppContext);
+
+  const languageOptions = config.SITE_SUPPORTED_LANGUAGES;
+  const [currentLocale, setCurrentLocale] = useState(getLocale());
+
+  /**
+   * Handles the selection of a language from the dropdown.
+   * Only triggers language change if the selected language is different from the current one.
+   *
+   * @param {string} selectedLocale - The locale code selected by the user
+   */
+  const handleSelect = (selectedLocale) => {
+    if (currentLocale !== selectedLocale) {
+      changeUserSessionLanguage(selectedLocale);
+      setCurrentLocale(selectedLocale);
+    }
+  };
+
+  const currentLangCode = getPrimaryLanguageSubtag(currentLocale).toUpperCase();
+  const currentlangDisplayName = getDisplayName(currentLocale);
+
+  // Don't render the component if there are no language options
+  if (!Array.isArray(languageOptions)
+    || languageOptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`${className} language-selector`} id="language-selector">
+      <Dropdown onSelect={handleSelect}>
+        <Dropdown.Toggle
+          id="lang-selector-dropdown"
+          iconBefore={Language}
+          variant="outline-primary"
+          size="sm"
+        >
+          <span className="lang-label-medium">{currentLangCode}</span>
+          <span className="lang-label-large">{currentlangDisplayName}</span>
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {languageOptions.map((locale) => (
+            <Dropdown.Item key={`lang-selector-${locale}`} eventKey={locale}>
+              {getDisplayName(locale)}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  );
+};
+
+LanguageSelector.propTypes = {
+  className: PropTypes.string,
+};
+
+LanguageSelector.defaultProps = {
+  className: '',
+};
+
+export default injectIntl(LanguageSelector);

--- a/src/language-selector/LanguageSelector.scss
+++ b/src/language-selector/LanguageSelector.scss
@@ -1,0 +1,22 @@
+.language-selector {
+  padding: .75rem;
+
+  .dropdown-toggle {
+    .lang-label-medium,
+    .lang-label-large {
+      display: none;
+    }
+
+    @media (min-width: 576px) and (max-width: 767px) {
+      .lang-label-medium {
+        display: inline;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .lang-label-large {
+        display: inline;
+      }
+    }
+  }
+}

--- a/src/language-selector/LanguageSelector.test.jsx
+++ b/src/language-selector/LanguageSelector.test.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { mergeConfig } from '@edx/frontend-platform';
+import { getLocale } from '@edx/frontend-platform/i18n/lib';
+import { changeUserSessionLanguage } from '@edx/frontend-platform/i18n';
+import {
+  act, fireEvent, initializeMockApp, render, screen,
+} from '../setupTest';
+import LanguageSelector from './LanguageSelector';
+
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  changeUserSessionLanguage: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('@edx/frontend-platform/i18n/lib', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n/lib'),
+  getLocale: jest.fn(),
+}));
+
+jest.mock('@openedx/paragon/icons', () => ({
+  Language: () => <div>LanguageIcon</div>,
+}));
+
+jest.mock('@openedx/paragon', () => ({
+  ...jest.requireActual('@openedx/paragon'),
+  useWindowSize: () => ({ width: global.innerWidth }),
+}));
+
+const LANGUAGE_PREFERENCE_COOKIE_NAME = 'language-preference';
+
+describe('LanguageSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mergeConfig({
+      ENABLE_HEADER_LANG_SELECTOR: true,
+      LANGUAGE_PREFERENCE_COOKIE_NAME,
+      SITE_SUPPORTED_LANGUAGES: ['es', 'en'],
+    });
+
+    initializeMockApp();
+
+    global.innerWidth = 1200;
+  });
+
+  it('should not render when no supported languages are available', () => {
+    mergeConfig({
+      SITE_SUPPORTED_LANGUAGES: [],
+    });
+
+    const { container } = render(<LanguageSelector />);
+    // expect(container).toMatchSnapshot('no-supported-languages');
+    expect(container.querySelector('#language-selector')).toBeNull();
+  });
+
+  it('should change the language when different language is selected', async () => {
+    getLocale.mockReturnValue('en');
+
+    const { container } = render(<LanguageSelector />);
+    expect(container).toMatchSnapshot('before-language-change');
+
+    const langDropdown = screen.getByRole('button', { id: 'lang-selector-dropdown' });
+    fireEvent.click(langDropdown);
+
+    const spanishOption = screen.getByRole('button', { name: 'Español' });
+
+    await act(async () => {
+      fireEvent.click(spanishOption);
+    });
+
+    expect(container).toMatchSnapshot('after-language-change');
+    expect(changeUserSessionLanguage).toHaveBeenCalledWith('es');
+  });
+
+  it('should not change language if the same language is selected', async () => {
+    getLocale.mockReturnValue('en');
+
+    const { container } = render(<LanguageSelector />);
+    expect(container).toMatchSnapshot('before-same-language-selection');
+
+    const langDropdown = screen.getByRole('button', { id: 'lang-selector-dropdown' });
+    fireEvent.click(langDropdown);
+
+    const englishOption = screen.getByRole('button', { name: 'English' });
+    await act(async () => {
+      fireEvent.click(englishOption);
+    });
+
+    expect(container).toMatchSnapshot('after-same-language-selection');
+    expect(changeUserSessionLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should display full language name on large screens', () => {
+    getLocale.mockReturnValue('en');
+
+    global.innerWidth = 1200;
+    render(<LanguageSelector />);
+
+    const button = screen.getByRole('button', { id: 'lang-selector-dropdown' });
+    expect(button).toMatchSnapshot('large-screen-button');
+  });
+
+  it('should display language code on medium screens', () => {
+    getLocale.mockReturnValue('en');
+
+    global.innerWidth = 700;
+    render(<LanguageSelector />);
+
+    const button = screen.getByRole('button', { id: 'lang-selector-dropdown' });
+    expect(button).toMatchSnapshot('medium-screen-button');
+  });
+
+  it('should display only icon on small screens', () => {
+    getLocale.mockReturnValue('en');
+
+    global.innerWidth = 500;
+    render(<LanguageSelector />);
+
+    const button = screen.getByRole('button', { id: 'lang-selector-dropdown' });
+    expect(button).toMatchSnapshot('small-screen-button');
+  });
+});

--- a/src/language-selector/__snapshots__/LanguageSelector.test.jsx.snap
+++ b/src/language-selector/__snapshots__/LanguageSelector.test.jsx.snap
@@ -1,0 +1,303 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LanguageSelector should change the language when different language is selected: after-language-change 1`] = `
+<div>
+  <div
+    data-testid="browser-router"
+  >
+    <div
+      class=" language-selector"
+      id="language-selector"
+    >
+      <div
+        class="pgn__dropdown pgn__dropdown-light dropdown"
+        data-testid="dropdown"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle btn btn-outline-primary btn-sm"
+          id="lang-selector-dropdown"
+          type="button"
+        >
+          <span
+            class="pgn__icon pgn__icon__sm btn-icon-before"
+          >
+            <div>
+              LanguageIcon
+            </div>
+          </span>
+          <span
+            class="lang-label-medium"
+          >
+            ES
+          </span>
+          <span
+            class="lang-label-large"
+          >
+            Español
+          </span>
+        </button>
+        <div
+          aria-labelledby="lang-selector-dropdown"
+          class="dropdown-menu"
+          style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none; margin: 0px;"
+          x-placement="bottom-start"
+        >
+          <a
+            class="pgn__dropdown-item dropdown-item"
+            href="#"
+            role="button"
+          >
+            Español
+          </a>
+          <a
+            class="pgn__dropdown-item dropdown-item"
+            href="#"
+            role="button"
+          >
+            English
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LanguageSelector should change the language when different language is selected: before-language-change 1`] = `
+<div>
+  <div
+    data-testid="browser-router"
+  >
+    <div
+      class=" language-selector"
+      id="language-selector"
+    >
+      <div
+        class="pgn__dropdown pgn__dropdown-light dropdown"
+        data-testid="dropdown"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle btn btn-outline-primary btn-sm"
+          id="lang-selector-dropdown"
+          type="button"
+        >
+          <span
+            class="pgn__icon pgn__icon__sm btn-icon-before"
+          >
+            <div>
+              LanguageIcon
+            </div>
+          </span>
+          <span
+            class="lang-label-medium"
+          >
+            EN
+          </span>
+          <span
+            class="lang-label-large"
+          >
+            English
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LanguageSelector should display full language name on large screens: large-screen-button 1`] = `
+<button
+  aria-expanded="false"
+  aria-haspopup="true"
+  class="dropdown-toggle btn btn-outline-primary btn-sm"
+  id="lang-selector-dropdown"
+  type="button"
+>
+  <span
+    class="pgn__icon pgn__icon__sm btn-icon-before"
+  >
+    <div>
+      LanguageIcon
+    </div>
+  </span>
+  <span
+    class="lang-label-medium"
+  >
+    EN
+  </span>
+  <span
+    class="lang-label-large"
+  >
+    English
+  </span>
+</button>
+`;
+
+exports[`LanguageSelector should display language code on medium screens: medium-screen-button 1`] = `
+<button
+  aria-expanded="false"
+  aria-haspopup="true"
+  class="dropdown-toggle btn btn-outline-primary btn-sm"
+  id="lang-selector-dropdown"
+  type="button"
+>
+  <span
+    class="pgn__icon pgn__icon__sm btn-icon-before"
+  >
+    <div>
+      LanguageIcon
+    </div>
+  </span>
+  <span
+    class="lang-label-medium"
+  >
+    EN
+  </span>
+  <span
+    class="lang-label-large"
+  >
+    English
+  </span>
+</button>
+`;
+
+exports[`LanguageSelector should display only icon on small screens: small-screen-button 1`] = `
+<button
+  aria-expanded="false"
+  aria-haspopup="true"
+  class="dropdown-toggle btn btn-outline-primary btn-sm"
+  id="lang-selector-dropdown"
+  type="button"
+>
+  <span
+    class="pgn__icon pgn__icon__sm btn-icon-before"
+  >
+    <div>
+      LanguageIcon
+    </div>
+  </span>
+  <span
+    class="lang-label-medium"
+  >
+    EN
+  </span>
+  <span
+    class="lang-label-large"
+  >
+    English
+  </span>
+</button>
+`;
+
+exports[`LanguageSelector should not change language if the same language is selected: after-same-language-selection 1`] = `
+<div>
+  <div
+    data-testid="browser-router"
+  >
+    <div
+      class=" language-selector"
+      id="language-selector"
+    >
+      <div
+        class="pgn__dropdown pgn__dropdown-light dropdown"
+        data-testid="dropdown"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle btn btn-outline-primary btn-sm"
+          id="lang-selector-dropdown"
+          type="button"
+        >
+          <span
+            class="pgn__icon pgn__icon__sm btn-icon-before"
+          >
+            <div>
+              LanguageIcon
+            </div>
+          </span>
+          <span
+            class="lang-label-medium"
+          >
+            EN
+          </span>
+          <span
+            class="lang-label-large"
+          >
+            English
+          </span>
+        </button>
+        <div
+          aria-labelledby="lang-selector-dropdown"
+          class="dropdown-menu"
+          style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none; margin: 0px;"
+          x-placement="bottom-start"
+        >
+          <a
+            class="pgn__dropdown-item dropdown-item"
+            href="#"
+            role="button"
+          >
+            Español
+          </a>
+          <a
+            class="pgn__dropdown-item dropdown-item"
+            href="#"
+            role="button"
+          >
+            English
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LanguageSelector should not change language if the same language is selected: before-same-language-selection 1`] = `
+<div>
+  <div
+    data-testid="browser-router"
+  >
+    <div
+      class=" language-selector"
+      id="language-selector"
+    >
+      <div
+        class="pgn__dropdown pgn__dropdown-light dropdown"
+        data-testid="dropdown"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle btn btn-outline-primary btn-sm"
+          id="lang-selector-dropdown"
+          type="button"
+        >
+          <span
+            class="pgn__icon pgn__icon__sm btn-icon-before"
+          >
+            <div>
+              LanguageIcon
+            </div>
+          </span>
+          <span
+            class="lang-label-medium"
+          >
+            EN
+          </span>
+          <span
+            class="lang-label-large"
+          >
+            English
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/language-selector/index.js
+++ b/src/language-selector/index.js
@@ -1,0 +1,3 @@
+import LanguageSelector from './LanguageSelector';
+
+export default LanguageSelector;

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -11,6 +11,7 @@ import CourseInfoSlot from '../plugin-slots/CourseInfoSlot';
 import { courseInfoDataShape } from './LearningHeaderCourseInfo';
 import messages from './messages';
 import LearningHeaderActionsSlot from '../plugin-slots/LearningHeaderActionsSlot';
+import LanguageSelector from '../language-selector';
 
 const LearningHeader = ({
   courseOrg,
@@ -37,6 +38,7 @@ const LearningHeader = ({
         <div className="flex-grow-1 course-title-lockup d-flex" style={{ lineHeight: 1 }}>
           <CourseInfoSlot courseOrg={courseOrg} courseNumber={courseNumber} courseTitle={courseTitle} />
         </div>
+        {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
         {showUserDropdown && authenticatedUser && (
         <>
           <LearningHeaderActionsSlot />

--- a/src/studio-header/HeaderBody.tsx
+++ b/src/studio-header/HeaderBody.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode, type ComponentProps } from 'react';
+import { getConfig } from '@edx/frontend-platform';
 import classNames from 'classnames';
 import {
   ActionRow,
@@ -13,6 +14,7 @@ import CourseLockUp from './CourseLockUp';
 import UserMenu from './UserMenu';
 import BrandNav from './BrandNav';
 import NavDropdownMenu from './NavDropdownMenu';
+import LanguageSelector from '../language-selector';
 import StudioHeaderActionsSlot from '../plugin-slots/StudioHeaderActionsSlot';
 
 export interface HeaderBodyProps {
@@ -136,6 +138,7 @@ const HeaderBody = ({
           </>
         )}
         <ActionRow.Spacer />
+        {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
         <StudioHeaderActionsSlot
           searchButtonAction={searchButtonAction}
         />


### PR DESCRIPTION
## Description 

This adds a new language selector to the learning(sed by learning) header and desktop(used by learner-dashboard) header 

Issue # [1474](https://edunext.atlassian.net/browse/FUTUREX-1474)
Migration pr of [#6](https://github.com/nelc/frontend-component-header/pull/6) and [#9](https://github.com/nelc/frontend-component-header/pull/9) 

## How to test
1. Checkout the required branches [frontend-component-header](https://github.com/nelc/frontend-component-header/tree/and/FUTUREX-1474) and [frontend-platform](https://github.com/nelc/frontend-platform/tree/and/FUTUREX-1469)
2. Set both dependencies as editable in your MFE,e.g
``` js
module.exports = {
    /*
    Modules you want to use from local source code.  Adding a module here means that when this app
    runs its build, it'll resolve the source from peer directories of this app.
  
    moduleName: the name you use to import code from the module.
    dir: The relative path to the module's source code.
    dist: The sub-directory of the source code where it puts its build artifact.  Often "dist".
    */
    localModules: [
        { moduleName: '@edx/frontend-platform', dir: '../frontend-platform', dist: 'src' },
        { moduleName: '@edx/frontend-component-header/dist', dir: '../frontend-component-header', dist: 'src' },
        { moduleName: '@edx/frontend-component-header', dir: '../frontend-component-header', dist: 'src' },
    ],
};
```
3. Add the following settings to your local environment
``` python
MFE_CONFIG["SITE_SUPPORTED_LANGUAGES"] = ["en", "ar"]
MFE_CONFIG["ENABLE_HEADER_LANG_SELECTOR"] = True
```
4. Download your MFE messages 
`export PATH="$(pwd)/node_modules/.bin:$PATH"`
`make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository=nelc/futurex-translations --revision=open-release/redwood.master" pull_translation`
5. Go to your mfe an check the language selector behavior 



https://github.com/user-attachments/assets/5f4fa060-cf58-4ac3-aab8-5089027e9680




