### PR TITLE
feat: add lisan-ai component

### DIFF
--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
-import { ProfileDataModal } from '@edunext/frontend-essentials';
+import { ProfileDataModal, LisanAI } from '@edunext/frontend-essentials';
 
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
@@ -40,6 +40,7 @@ const LearningHeader = ({
           <CourseInfoSlot courseOrg={courseOrg} courseNumber={courseNumber} courseTitle={courseTitle} />
         </div>
         {getConfig().ENABLE_HEADER_LANG_SELECTOR && (<LanguageSelector />)}
+        {getConfig().LISAN_AI_ENABLED && (<LisanAI />)}
         {showUserDropdown && authenticatedUser && (
         <>
           <LearningHeaderActionsSlot />

--- a/src/studio-header/StudioHeader.tsx
+++ b/src/studio-header/StudioHeader.tsx
@@ -1,7 +1,8 @@
 import React, { type FunctionComponent, useContext } from 'react';
 import Responsive from 'react-responsive';
 import { AppContext } from '@edx/frontend-platform/react';
-import { ensureConfig } from '@edx/frontend-platform';
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { LisanAI } from '@edunext/frontend-essentials';
 
 import MobileHeader from './MobileHeader';
 import HeaderBody, { HeaderBodyProps } from './HeaderBody';
@@ -63,6 +64,7 @@ const StudioHeader: FunctionComponent<Props> = ({
 
   return (
     <div className="studio-header">
+      {getConfig().LISAN_AI_ENABLED && (<LisanAI />)}
       <a className="nav-skip sr-only sr-only-focusable" href="#main">Skip to content</a>
       <Responsive maxWidth={841}>
         <MobileHeader {...props} />


### PR DESCRIPTION
## Description
This adds the frontend-essentials LisanAI component.

Issue # [1473](https://edunext.atlassian.net/browse/FUTUREX-1473)
This is a migration pr of https://github.com/nelc/frontend-component-header/pull/7 


## How to test
1. Set the testing mfe, in this case: discussions
2. Add the module.config.js  file
``` js
module.exports = {
    /*
    Modules you want to use from local source code.  Adding a module here means that when this app
    runs its build, it'll resolve the source from peer directories of this app.
  
    moduleName: the name you use to import code from the module.
    dir: The relative path to the module's source code.
    dist: The sub-directory of the source code where it puts its build artifact.  Often "dist".
    */
    localModules: [
        { moduleName: '@edx/frontend-component-header/dist', dir: '../frontend-component-header', dist: 'src' },
        { moduleName: '@edx/frontend-component-header', dir: '../frontend-component-header', dist: 'src' },
    ],
};

```
3. Checkout this branch 
4. Add the required settings
```python
MFE_CONFIG_OVERRIDES = {
    "discussions": {
        "LISAN_AI_CLIENT_ID": "SECRET",
        "LISAN_AI_ENABLED": True,
    }
}
```
5. Go to discussion and add a new post
6. Test the behavior 


https://github.com/user-attachments/assets/8385f2eb-47db-4ca7-b02d-4345b2875a5f



